### PR TITLE
[BUGFIX] Move instantiation of LanguageService and FileRepository

### DIFF
--- a/Classes/Form/Element/ShowDeleteFiles.php
+++ b/Classes/Form/Element/ShowDeleteFiles.php
@@ -26,17 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ShowDeleteFiles extends AbstractFormElement
 {
-    /**
-     * Container objects give $nodeFactory down to other containers.
-     *
-     * @param FileRepository $fileRepository
-     * @param LanguageService $languageService
-     */
-    public function __construct(
-        protected readonly FileRepository $fileRepository,
-        protected readonly LanguageService $languageService
-    ) {
-    }
+
 
     /**
      * @return array
@@ -44,8 +34,9 @@ class ShowDeleteFiles extends AbstractFormElement
     public function render(): array
     {
         $result = $this->initializeResultArray();
-
-        $rows = $this->fileRepository->countByIdentifier($this->data['vanillaUid']);
+        $languageService = $this->instanceLanguageService();
+        $fileRepository = GeneralUtility::makeInstance(FileRepository::class);
+        $rows = $fileRepository->countByIdentifier($this->data['vanillaUid']);
 
         // TODO https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-97330-FormEngineElementClassesMustCreateLabelOrLegend.html
 
@@ -54,7 +45,7 @@ class ShowDeleteFiles extends AbstractFormElement
 
         if (empty($rows)) {
             $html[] = '<span class="badge badge-success">'
-                . $this->languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.no_delete')
+                . $languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.no_delete')
                 . '</span>';
         } else {
             $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
@@ -65,9 +56,9 @@ class ShowDeleteFiles extends AbstractFormElement
                 $html[] = '<a class="btn btn-default t3js-editform-submitButton" data-name="_save_tx_filefill_delete" data-form="EditDocumentController" data-value="' . $row['tx_filefill_identifier'] . '">';
                 $html[] = $iconFactory->getIcon('actions-edit-delete', IconSize::SMALL);
                 $html[] = ' ' . sprintf(
-                    $this->languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.delete_files'),
+                    $languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.delete_files'),
                     $row['count'],
-                    $this->languageService->sL($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['resourceHandler'][$row['tx_filefill_identifier']]['title'] ?? $row['tx_filefill_identifier'])
+                    $languageService->sL($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['resourceHandler'][$row['tx_filefill_identifier']]['title'] ?? $row['tx_filefill_identifier'])
                 );
                 $html[] = '</a>';
             }
@@ -77,5 +68,9 @@ class ShowDeleteFiles extends AbstractFormElement
         $result['html'] = implode('', $html);
 
         return $result;
+    }
+    private function instanceLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
     }
 }

--- a/Classes/Form/Element/ShowMissingFiles.php
+++ b/Classes/Form/Element/ShowMissingFiles.php
@@ -27,15 +27,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ShowMissingFiles extends AbstractFormElement
 {
-    /**
-     * Container objects give $nodeFactory down to other containers.
-     *
-     * @param LanguageService|null $languageService
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(protected readonly LanguageService $languageService)
-    {
-    }
 
     /**
      * @return array
@@ -43,7 +34,7 @@ class ShowMissingFiles extends AbstractFormElement
     public function render(): array
     {
         $result = $this->initializeResultArray();
-
+        $languageService = $this->instanceLanguageService();
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file');
         $expressionBuilder = $queryBuilder->expr();
         $count = $queryBuilder->count('*')
@@ -68,13 +59,13 @@ class ShowMissingFiles extends AbstractFormElement
 
         if ($count === 0) {
             $html[] = '<span class="badge badge-success">'
-                . $this->languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.no_missing')
+                . $languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.no_missing')
                 . '</span>';
         } else {
             $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
             $html[] = '<span class="badge badge-danger">'
                 . sprintf(
-                    $this->languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.missing_files'),
+                    $languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.missing_files'),
                     $count
                 )
                 . '</span>';
@@ -82,7 +73,7 @@ class ShowMissingFiles extends AbstractFormElement
             $html[] = '<div class="form-control-wrap t3js-module-docheader">';
             $html[] = '<a class="btn btn-default t3js-editform-submitButton" data-name="_save_tx_filefill_missing" data-form="EditDocumentController" data-value="1">';
             $html[] = $iconFactory->getIcon('actions-database-reload', IconSize::SMALL);
-            $html[] = ' ' . $this->languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.reset');
+            $html[] = ' ' . $languageService->sL('LLL:EXT:filefill/Resources/Private/Language/locallang_db.xlf:sys_file_storage.filefill.reset');
             $html[] = '</a>';
         }
 
@@ -91,5 +82,10 @@ class ShowMissingFiles extends AbstractFormElement
         $result['html'] = implode('', $html);
 
         return $result;
+    }
+
+    private function instanceLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
     }
 }


### PR DESCRIPTION
The `__construct` method in `ShowDeleteFiles` caused an autowiring issue due to `LanguageService` being excluded in `Configuration/Services.yaml`.   To resolve this, the instantiation of `LanguageService` and `FileRepository` was moved to the respective methods using `GeneralUtility::makeInstance()`.